### PR TITLE
Updated both bridge adapters

### DIFF
--- a/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/changelog.md
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/changelog.md
@@ -3,3 +3,6 @@ Google Admin (2020-10-27)
  * Updated dependency versions
    * kinetic-agent-adapter to v1.1.0
    * junit to 4.13.1
+
+Google Admin (2020-12-15)
+ * Updated configurable properties. The P12 File Location and Private Key fields should be conditionally required based on the Authorization Type value.

--- a/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/pom.xml
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.bridges.adapter</groupId>
     <artifactId>kinetic-bridgehub-adapter-googleadmin</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/src/main/java/com/kineticdata/bridgehub/adapter/google/GoogleAdminAdapter.java
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googleadmin/src/main/java/com/kineticdata/bridgehub/adapter/google/GoogleAdminAdapter.java
@@ -89,9 +89,11 @@ public class GoogleAdminAdapter implements BridgeAdapter {
             .setPossibleValues("P12 File", "Private Key")
             .setValue("P12 File"),
         new ConfigurableProperty(Properties.P12_FILE)
-            .setDependency(Properties.AUTHORIZATION_TYPE, "P12 File"),
+            .setDependency(Properties.AUTHORIZATION_TYPE, "P12 File")
+            .setIsRequired(true),
         new ConfigurableProperty(Properties.PRIVATE_KEY)
             .setDependency(Properties.AUTHORIZATION_TYPE, "Private Key")
+            .setIsRequired(true)
             .setIsSensitive(true),
         new ConfigurableProperty(Properties.USER_IMPERSONATION).setIsRequired(true),
         new ConfigurableProperty(Properties.DOMAIN).setIsRequired(false)

--- a/bridge-adapters/kinetic-bridgehub-adapter-googledrive/changelog.md
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googledrive/changelog.md
@@ -1,3 +1,6 @@
-Google Drive (20202-10-27)
+Google Drive (2020-10-27)
  * Added Private Key support
  * Updated dependency, kinetic-agent-adapter to 1.1.0
+
+Google Drive (2020-12-15)
+ * Updated configurable properties.  The P12 File Location and Private Key fields should be conditionally required based on the Authorization Type value.

--- a/bridge-adapters/kinetic-bridgehub-adapter-googledrive/pom.xml
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googledrive/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.kineticdata.bridges.adapter</groupId>
     <artifactId>kinetic-bridgehub-adapter-googledrive</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>kinetic-bridgehub-adapter-googledrive</name>

--- a/bridge-adapters/kinetic-bridgehub-adapter-googledrive/src/main/java/com/kineticdata/bridgehub/adapter/googledrive/GoogleDriveAdapter.java
+++ b/bridge-adapters/kinetic-bridgehub-adapter-googledrive/src/main/java/com/kineticdata/bridgehub/adapter/googledrive/GoogleDriveAdapter.java
@@ -89,9 +89,11 @@ public class GoogleDriveAdapter implements BridgeAdapter {
             .setPossibleValues("P12 File", "Private Key")
             .setValue("P12 File"),
         new ConfigurableProperty(Properties.P12_FILE)
-            .setDependency(Properties.AUTHORIZATION_TYPE, "P12 File"),
+            .setDependency(Properties.AUTHORIZATION_TYPE, "P12 File")
+            .setIsRequired(true),
         new ConfigurableProperty(Properties.PRIVATE_KEY)
             .setDependency(Properties.AUTHORIZATION_TYPE, "Private Key")
+            .setIsRequired(true)
             .setIsSensitive(true),
         new ConfigurableProperty(Properties.PROPERTY_USER_IMPERSONATION).setIsRequired(true),            
         new ConfigurableProperty(Properties.PROPERTY_EXPIRATION_SCRIPT)

--- a/changelog.md
+++ b/changelog.md
@@ -7,3 +7,10 @@ Google Apps [bridge-adapter] (2020-10-27)
  * [kinetic-bridge-adapter-googledrive]
    * Added support for Private Key
    * Upgraded kinetic-agent-adapter dependency
+
+Google Apps [bridge-adapter] (2020-12-15)
+ * [kinetic-bridge-adapter-googleadmin]
+   * updated configurable properties
+
+ * [kinetic-bridge-adapter-googledrive]
+   * updated configurable properties


### PR DESCRIPTION
The P12 File Location and Private Key fields should be conditionally required
 based on the Authorization Type value.  This was added to the configurable
 properties for both adapters.